### PR TITLE
fix: fix warning when using VS1053

### DIFF
--- a/yoRadio/platformio.ini
+++ b/yoRadio/platformio.ini
@@ -69,7 +69,6 @@ build_flags =
   #-DCOLOR_BITRATE=255,0,0
   #-DCOLOR_VU_MAX=255,0,0
   #-DCOLOR_VU_MIN=0,255,0
-  -DVS1053_CS=255
   # force adafruit gfx lib to use yoradio font
   -include "fonts/glcdfont_EN.c"
   #-D CORE_DEBUG_LEVEL=3                    ; 0 None, 1 Error, 2 Warn, 3 Info, 4 Debug, 5 Verbose

--- a/yoRadio/src/audioI2S/Audio.cpp
+++ b/yoRadio/src/audioI2S/Audio.cpp
@@ -1,3 +1,4 @@
+#include "../core/options.h"
 #if VS1053_CS==255
 /*
  * Audio.cpp


### PR DESCRIPTION
With the change in 17de6cf we get a warning about overwriting define VS1053_CS when we use a target which uses VS1053.
Appending '-UVS1053_CS' did not help.
The include of options.h was accidentally removed in a4da15a.