### PR TITLE
fix: fix error when defining some button but not all

### DIFF
--- a/yoRadio/src/OneButton/OneButton.cpp
+++ b/yoRadio/src/OneButton/OneButton.cpp
@@ -39,6 +39,10 @@ OneButton::OneButton(const int pin, const boolean activeLow, const bool pullupAc
   // OneButton();
   _pin = pin;
 
+  if (pin == 255)
+    // 255 is an invalid pin number. stop the initializing of the class.
+    return;
+
   if (activeLow) {
     // the button connects the input pin to GND when pressed.
     _buttonPressed = LOW;

--- a/yoRadio/src/core/controls.cpp
+++ b/yoRadio/src/core/controls.cpp
@@ -142,7 +142,7 @@ void loopControls() {
 #if ISPUSHBUTTONS
   for (unsigned i = 0; i < nrOfButtons; i++)
   {
-    if ((i == 0 && BTN_LEFT == 255) || (i == 1 && BTN_CENTER == 255) || (i == 2 && BTN_RIGHT == 255) || (i == 3 && ENC_BTNB == 255) || (i == 4 && BTN_UP == 255) || (i == 5 && BTN_DOWN == 255) || (i == 6 && ENC2_BTNB == 255)) continue;
+    if ((i == 0 && BTN_LEFT == 255) || (i == 1 && BTN_CENTER == 255) || (i == 2 && BTN_RIGHT == 255) || (i == 3 && ENC_BTNB == 255) || (i == 4 && BTN_UP == 255) || (i == 5 && BTN_DOWN == 255) || (i == 6 && ENC2_BTNB == 255) || (i == 7 && BTN_MODE == 255)) continue;
     button[i].tick();
     if (lpId >= 0) {
       if (DSP_MODEL == DSP_DUMMY && (lpId == 4 || lpId == 5)) continue;


### PR DESCRIPTION
By returning in the constructor if the pin number is 255 we prevent the error during setup when calling pinMode with an invalid pin number.
```
[   312][E][esp32-hal-gpio.c:107] __pinMode(): Invalid IO 255 selected
```

By adding `(i == 7 && BTN_MODE == 255)` to the loop we prevent the error
```
[  2408][E][esp32-hal-periman.c:174] perimanGetPinBus(): Invalid pin: 255
[  2415][E][esp32-hal-gpio.c:188] __digitalRead(): IO 255 is not set as GPIO.
```

Fixes #9.