### PR TITLE
fix: update branch of esp32-arduino-libs

### DIFF
--- a/yoRadio/platformio.ini
+++ b/yoRadio/platformio.ini
@@ -30,7 +30,7 @@ lib_deps =
 
 platform_packages =
 	platformio/framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#3.0.0-rc1
-	platformio/framework-arduinoespressif32-libs @ https://github.com/espressif/esp32-arduino-libs.git#idf-v5.1.3
+	platformio/framework-arduinoespressif32-libs @ https://github.com/espressif/esp32-arduino-libs.git#idf-release/v5.1
 	; mkspiffs not found after adding via
 	;platformio/tool-mkspiffs@^2.230.0
 	;workaround:


### PR DESCRIPTION
The precompiled ESP-IDF libraries updated their branch on github. The old one is not available anymore.
This leads to an error if you start from scratch or build with a github action.
Locally you may need to remove the old one if you already checked it out with platformio.

```
rm -r ~/.platformio/packages/framework-arduinoespressif32-libs
```